### PR TITLE
Fixed typo in styles.css

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -155,7 +155,7 @@ body {
 .expansion-corporate {
     background-image: url('./assets/expansions/corporate.png');
 }
-.expansion-prelude {
+.expansion-preludes {
     background-image: url('./assets/expansions/prelude.png');
 }
 .expansion-promo {


### PR DESCRIPTION
Makes the prelude icon load. Expansion enum value is "preludes", while CSS was looking for ".expansion-prelude".

Love your app, by the way, great work!